### PR TITLE
nix-shell working

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+import ./shell.nix

--- a/inputs.nix
+++ b/inputs.nix
@@ -1,0 +1,18 @@
+
+with builtins;
+let
+  lock = fromTOML (readFile ./lock.toml);
+in rec {
+  pkgs = import (builtins.fetchTarball {
+    name = "nixpkgs";
+    url = "https://github.com/nixos/nixpkgs/tarball/${lock.nixpkgs.rev}";
+    sha256 = "${lock.nixpkgs.sha256}";
+  }) { config = {}; overlays = []; };
+  mach-nix = import (builtins.fetchTarball {
+    url = "https://github.com/DavHau/mach-nix/tarball/${lock.mach-nix.rev}";
+    sha256 = lock.mach-nix.sha256;
+  }) {
+    python = "python37";
+    inherit pkgs;
+  };
+}

--- a/lock.toml
+++ b/lock.toml
@@ -1,0 +1,9 @@
+[mach-nix]
+ref = "master"
+rev = "8d903072c7b5426d90bc42a008242c76590af916"
+sha256 = "1xmz1rzip6cwk7zhrakigl7zg04mrmsvlarcvhwk38zz0x7kbi10"
+
+[nixpkgs]
+ref = "554d2d8aa25b6e583575459c297ec23750adb6cb"
+rev = "554d2d8aa25b6e583575459c297ec23750adb6cb"
+sha256 = "01yfqslnkyrfb5yjfablhvw830iw0za3mab4n03a0ldyq5ac6wh1"

--- a/python.nix
+++ b/python.nix
@@ -1,0 +1,5 @@
+
+with (import ./inputs.nix);
+mach-nix.mkPython {
+  requirements = builtins.readFile ./requirements.txt;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+
+with (import ./inputs.nix);
+pkgs.mkShell {
+  buildInputs = [
+    (import ./python.nix)
+    mach-nix.mach-nix
+  ];
+}


### PR DESCRIPTION
User's only need to run `nix-shell` and get a fully operational python environment. Takes a while first run, but results are cached so it is much shorter after that. 